### PR TITLE
Update config-example with flapping fields for networks resources

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -8,6 +8,8 @@ services:
           project: <PROJECT_ID>
         gcp_log_resource_type: gce_network
         field_exclude_filter:
+          - selfLinkWithId
+          - networkFirewallPolicyEnforcementOrder
           - peerings:
               - stateDetails
         item_exclude_filter:


### PR DESCRIPTION
As Google is testing new fields for this resource, they seem to add/remove it constantly which causes periodic configuration in files without actual changes.