### PR TITLE
GCP API call paging limitation - fix

### DIFF
--- a/cloudimized/core/core.py
+++ b/cloudimized/core/core.py
@@ -277,7 +277,7 @@ class GcpOxidizer:
                     for future in as_completed(futures):
                         try:
                             result = future.result()
-                            if result is None:
+                            if len(result) == 0:
                                 logger.info(f"No '{resource_name}' resources found for project '{future.project_id}'")
                                 continue
                             self.run_results.add_result(resource_name, future.project_id, result)

--- a/cloudimized/gcpcore/gcpquery.py
+++ b/cloudimized/gcpcore/gcpquery.py
@@ -24,6 +24,9 @@ DEFAULT_NUM_RETRIES = 3
 AGGREGATED_LIST = "aggregatedList"
 DEFAULT_SORT_FIELDS = ["name"]
 
+GCP_PAGE_TOKEN = "pageToken"
+GCP_NEXT_PAGE_TOKEN = "nextPageToken"
+
 class GcpQuery:
     """A class for sending list query to GCP"""
 
@@ -84,6 +87,7 @@ class GcpQuery:
                     query_kwargs[k] = v.replace("<PROJECT_ID>", project_id)
                     logger.debug(f"Replacing <PROJECT_ID> string in param_name: {k}, param_value: {v} "
                                  f"with string {project_id}")
+        result = []
         try:
             # Build function call for resource
             # i.e. run service.projects().list()
@@ -92,15 +96,22 @@ class GcpQuery:
                          f"Query API call: {self.api_call}")
             api_last_call_method = self.api_call.split(".")[-1]
             query_base = reduce(lambda x, y: methodcaller(y)(x), self.api_call.split(".")[:-1], service)
-            logger.debug(f"Query base for API call: {query_base}\nAPI call kwargs: {query_kwargs}")
-            # Run last call on service with arguments if present i.e. (service.projects()).list()
-            request = methodcaller(api_last_call_method, **query_kwargs)(query_base)
-            logger.debug(f"API call request object: {request}")
-            response = request.execute(num_retries=self.num_retries)
-            logger.debug(f"API call response object: {response}")
+            while True:
+                logger.debug(f"Query base for API call: {query_base}\nAPI call kwargs: {query_kwargs}")
+                # Run last call on service with arguments if present i.e. (service.projects()).list()
+                request = methodcaller(api_last_call_method, **query_kwargs)(query_base)
+                logger.debug(f"API call request object: {request}")
+                response = request.execute(num_retries=self.num_retries)
+                logger.debug(f"API call response object: {response}")
+                result.extend(response.get(self.result_items_field, []))
+                #Continue until there is no further page
+                next_page_token = response.get(GCP_NEXT_PAGE_TOKEN, None)
+                if next_page_token is None:
+                    break
+                else:
+                    query_kwargs[GCP_PAGE_TOKEN] = next_page_token
         except Exception as e:
             raise GcpQueryError(f"Issue executing call '{self.api_call}' with args '{self.kwargs}'") from e
-        result = response.get(self.result_items_field, None)
         # Separate handling for aggregatedList call
         if api_last_call_method == AGGREGATED_LIST:
             result = self._parse_aggregated_list(result)

--- a/cloudimized/gcpcore/gcpquery.py
+++ b/cloudimized/gcpcore/gcpquery.py
@@ -87,7 +87,6 @@ class GcpQuery:
                     query_kwargs[k] = v.replace("<PROJECT_ID>", project_id)
                     logger.debug(f"Replacing <PROJECT_ID> string in param_name: {k}, param_value: {v} "
                                  f"with string {project_id}")
-        result = []
         try:
             # Build function call for resource
             # i.e. run service.projects().list()
@@ -96,6 +95,7 @@ class GcpQuery:
                          f"Query API call: {self.api_call}")
             api_last_call_method = self.api_call.split(".")[-1]
             query_base = reduce(lambda x, y: methodcaller(y)(x), self.api_call.split(".")[:-1], service)
+            result = []
             while True:
                 logger.debug(f"Query base for API call: {query_base}\nAPI call kwargs: {query_kwargs}")
                 # Run last call on service with arguments if present i.e. (service.projects()).list()
@@ -103,7 +103,11 @@ class GcpQuery:
                 logger.debug(f"API call request object: {request}")
                 response = request.execute(num_retries=self.num_retries)
                 logger.debug(f"API call response object: {response}")
-                result.extend(response.get(self.result_items_field, []))
+                current_result = response.get(self.result_items_field, [])
+                # Separated handling for aggregatedList call (that returned a response)
+                if api_last_call_method == AGGREGATED_LIST and isinstance(current_result, dict):
+                    current_result = self._parse_aggregated_list(current_result)
+                result.extend(current_result)
                 #Continue until there is no further page
                 next_page_token = response.get(GCP_NEXT_PAGE_TOKEN, None)
                 if next_page_token is None:
@@ -112,11 +116,6 @@ class GcpQuery:
                     query_kwargs[GCP_PAGE_TOKEN] = next_page_token
         except Exception as e:
             raise GcpQueryError(f"Issue executing call '{self.api_call}' with args '{self.kwargs}'") from e
-        # Separate handling for aggregatedList call
-        if api_last_call_method == AGGREGATED_LIST:
-            result = self._parse_aggregated_list(result)
-        if not result:
-            return result
         # Sort result list to get predictable results
         # Results from kubernetes cluster list call return non-consistent list order
         # Perform sorting based on "name" key if present
@@ -243,13 +242,9 @@ class GcpQuery:
                 if api_result_resource_name in region_response:
                     logger.debug(f"Found resource '{api_result_resource_name}' in region '{region}'")
                     result.extend(region_response[api_result_resource_name])
+            return result
         except Exception as e:
             raise GcpQueryError(f"Issue processing api_call_result") from e
-        # Return None to make it compatible with normal queries
-        if not result:
-            return None
-        else:
-            return result
 
 
 def configure_queries(queries: List[Dict[str, Any]]) -> Dict[str, GcpQuery]:


### PR DESCRIPTION
As per official docs https://cloud.google.com/resource-manager/reference/rest/v1/projects/list
If response contains too many items it will be paged. Single API call will not return whole response, so further requests are needed.